### PR TITLE
fix button status in PR when navigating from /pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ A [Chrome extension](https://chrome.google.com/webstore/detail/no-merge-today/ii
 
 ## permissions
 
-This extension declares 3 permissions in its manifest.json
+This extension declares 4 permissions in its manifest.json
 - `tabs`: is needed so if multiple tabs are open in Github pull request pages, all tabs can be notified of configuration changes in the action popup (like toggling merge on any day on/off);
 - `storage`: is needed to store the configuration of in which days the merge buttons should be blocked. It is also used to sync this config to your profile (if you login in with your profile in another Chrome instance, it should retrieve the same config);
 - `webNavigation`: is needed to correctly trigger the check for the buttons when doing a client-side navigation, without a full page reload, such as what happens when you are in `/pulls` inside some repository and clicks on any PR. If, instead, you navigate directly to the PR URL, a full page reload happens, but this permission is still needed for the other cases.
+- `webRequest`: is needed to register a listener for the merge status check request after the PR page is loaded, and to update the button status if needed.
 
 ## TODO
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
   "permissions": [
     "tabs",
     "storage",
-    "webNavigation"
+    "webNavigation",
+    "webRequest"
   ],
   "action": {
     "default_popup": "src/popup.html",

--- a/src/content-script.js
+++ b/src/content-script.js
@@ -93,7 +93,7 @@ const mutationObserver = new MutationObserver(() => {
 const startMutationObserver = () => mutationObserver.observe(container, { childList: true, subtree: true })
 const stopMutationObserver = () => mutationObserver.disconnect()
 
-const handleNavigation = (data) => {
+const handleButtonCheckListener = (data) => {
   // Reset, regardless we are going in or out of a PR page.
   originalState = null
   didToggleCanMerge = false
@@ -112,8 +112,9 @@ const handleMessages = (request, sender, sendResponse) => {
   const { type, data } = request
 
   switch (type) {
+    case 'after-check-merge-status':
     case 'navigation':
-      handleNavigation(data)
+      handleButtonCheckListener(data)
       break;
     case 'action-toggle':
       checkButtonForToday()

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -81,6 +81,17 @@ const main = () => {
     })
   }, navigationFilter)
 
+  // After PR page has loaded, GitHub will make a request to check the merge status.
+  // We listen for that request and notify the content script on the PR page, so it can trigger the check.
+  chrome.webRequest.onCompleted.addListener((details) => {
+    chrome.tabs.sendMessage(details.tabId, { type: 'after-check-merge-status', data: details });
+  }, {
+    urls: [
+      // We only listen for the request to check the merge status.
+      `${githubUrlPattern}/*/pull/*/partials/merging`
+    ]
+  });
+
   // Check the action icon once and then setup the listener for subsequent changes
   checkIconForToday()
   chrome.runtime.onMessage.addListener(handleMessages)


### PR DESCRIPTION
This PR fixes an issue where the merge button status is not updated when navigating from `/pulls` to the PR page.

Since GitHub only renders the merge button status after the PR page has been loaded, via a request to `/partials/merging`, the script wasn't able to update the status when the request is still in-flight. On the other hand, the merge button is rendered presumably using SSR when the page is loaded directly (or force reloaded), therefore this issue doesn't happen when navigating directly to the PR link.

The solution is to add a listener when GitHub is done checking the merge status, which by then the merge status button should be ready in the dom, and thus allowing the script to update the status accordingly.

Before:
![CleanShot 2023-04-01 at 11 28 37](https://user-images.githubusercontent.com/2998111/229263570-2a2b1c97-d1c9-472f-b47e-80034bbc141e.gif)

After:
![CleanShot 2023-04-01 at 11 26 53](https://user-images.githubusercontent.com/2998111/229263503-3d961c33-c810-4bdf-b7cc-ad37083bf526.gif)